### PR TITLE
Change hashbang line to not hard-code Python path.

### DIFF
--- a/bin/filterOutShortAlignments.py
+++ b/bin/filterOutShortAlignments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import subprocess

--- a/bin/filterShortReads.py
+++ b/bin/filterShortReads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/bin/formatLongReads.py
+++ b/bin/formatLongReads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/bin/prepareRawLongReads.py
+++ b/bin/prepareRawLongReads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import subprocess

--- a/bin/split.py
+++ b/bin/split.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/bin/trim.py
+++ b/bin/trim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 


### PR DESCRIPTION
Python 3 is not always at /usr/bin/python3, so the hashbang line was causing errors for us on a system where it isn't.  I believe /usr/bin/env python3 is preferable for portability, if not best practice.

Thank you for sharing this software.